### PR TITLE
Enhanced handling error when downloading an image from iCloud fails

### DIFF
--- a/src/ios/DMCMediaPicker/de.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/de.lproj/Localizable.strings
@@ -10,3 +10,4 @@
 "Please allow to access your album" = "Bitte erlaube den Zugriff auf Dein Album in \"Einstellungen -> Datenschutz -> Fotos\"";
 "Setting" = "Einstellungen";
 "Preview" = "Vorschau";
+"photo_download_failed" = "Beim Herunterladen ausgewählter Fotos aus Ihrer iCloud-Fotobibliothek ist ein Fehler aufgetreten. Dies könnte an einer schlechten Internetverbindung liegen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut";

--- a/src/ios/DMCMediaPicker/en.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/en.lproj/Localizable.strings
@@ -9,3 +9,4 @@
 "Please allow to access your album" = "Please allow to access your album in \"Settings -> Privacy -> Album\"";
 "Setting" = "Setting";
 "Preview" = "Preview";
+"photo_download_failed" = "There was an error downloading selected photos from your iCloud Photo Library. This could be due to poor internet connectivity. Please check your internet connection and try again";

--- a/src/ios/DMCMediaPicker/es.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/es.lproj/Localizable.strings
@@ -9,3 +9,5 @@
 "Please allow to access your album" = "Por favor permita el acceso a sus albums en \"Configuraciones -> Privacidad -> Album\"";
 "Setting" = "Configuraciones";
 "Preview" = "Vista previa";
+"photo_download_failed" = "Se produjo un error al descargar las fotos seleccionadas de su biblioteca de fotos de iCloud. Esto podría deberse a una mala conectividad a Internet. Verifique su conexión a Internet e intente nuevamente";
+

--- a/src/ios/DMCMediaPicker/pt-BR.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/pt-BR.lproj/Localizable.strings
@@ -9,3 +9,5 @@
 "Please allow to access your album" = "Por favor permita acessar o seu álbum em \“Configurações -> Privacidade -> Álbum\"";
 "Setting" = "Configuração";
 "Preview" = "Prévia";
+"photo_download_failed" = "Ocorreu um erro ao baixar as fotos selecionadas da sua biblioteca de fotos do iCloud. Isso pode ser devido à falta de conectividade com a Internet. Por favor verifique sua conexão com a internet e tente novamente";
+

--- a/src/ios/DMCMediaPicker/pt-PT.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/pt-PT.lproj/Localizable.strings
@@ -9,3 +9,4 @@
 "Please allow to access your album" = "Por favor permita acessar o seu álbum em \“Configurações -> Privacidade -> Álbum\"";
 "Setting" = "Configuração";
 "Preview" = "Prévia";
+"photo_download_failed" = "Ocorreu um erro ao baixar as fotos selecionadas da sua biblioteca de fotos do iCloud. Isso pode ser devido à falta de conectividade com a Internet. Por favor verifique sua conexão com a internet e tente novamente";

--- a/src/ios/DMCMediaPicker/tr.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/tr.lproj/Localizable.strings
@@ -9,3 +9,4 @@
 "Please allow to access your album" = "Lütfen \"Ayarlar -> Gizlilik -> Fotoğraflar\" menüsünden uygulamaya erişim izni verin.";
 "Setting" = "Ayarlar";
 "Preview" = "Ön izleme";
+"photo_download_failed" = "İCloud Fotoğraf Kitaplığınızdan seçilen fotoğraflar indirilirken bir hata oluştu. Bunun nedeni zayıf internet bağlantısı olabilir. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin";

--- a/src/ios/DMCMediaPicker/zh-Hans.lproj/Localizable.strings
+++ b/src/ios/DMCMediaPicker/zh-Hans.lproj/Localizable.strings
@@ -9,3 +9,4 @@
 "Please allow to access your album" = "请在设置-隐私-相册中允许访问相册";
 "Setting" = "设置";
 "Preview" = "预览";
+"photo_download_failed" = "从您的iCloud照片库下载所选照片时出错。这可能是由于互联网连接状况不佳。请检查您的互联网连接，然后重试";

--- a/src/ios/MediaPicker.m
+++ b/src/ios/MediaPicker.m
@@ -84,23 +84,26 @@
         [self.commandDelegate evalJs:compressCompletedjs];
     };
     [[PHImageManager defaultManager] requestImageDataForAsset:asset  options:options resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
-        NSString *filename=[asset valueForKey:@"filename"];
-        NSString *fullpath=[NSString stringWithFormat:@"%@/%@%@", dmcPickerPath,[[NSProcessInfo processInfo] globallyUniqueString], filename];
-        NSNumber *size=[NSNumber numberWithLong:imageData.length];
+        if(imageData != nil) {
+            NSString *filename=[asset valueForKey:@"filename"];
+            NSString *fullpath=[NSString stringWithFormat:@"%@/%@%@", dmcPickerPath,[[NSProcessInfo processInfo] globallyUniqueString], filename];
+            NSNumber *size=[NSNumber numberWithLong:imageData.length];
 
-        NSError *error = nil;
-        if (![imageData writeToFile:fullpath options:NSAtomicWrite error:&error]) {
-            NSLog(@"%@", [error localizedDescription]);
-            [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:callbackId];
-        } else {
-            
-            NSDictionary *dict=[NSDictionary dictionaryWithObjectsAndKeys:fullpath,@"path",[[NSURL fileURLWithPath:fullpath] absoluteString],@"uri",@"image",@"mediaType",size,@"size",[NSNumber numberWithInt:index],@"index", nil];
-            [aListArray addObject:dict];
-            if([aListArray count]==[selectArray count]){
-                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:aListArray] callbackId:callbackId];
+            NSError *error = nil;
+            if (![imageData writeToFile:fullpath options:NSAtomicWrite error:&error]) {
+                NSLog(@"%@", [error localizedDescription]);
+                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:callbackId];
+            } else {
+                
+                NSDictionary *dict=[NSDictionary dictionaryWithObjectsAndKeys:fullpath,@"path",[[NSURL fileURLWithPath:fullpath] absoluteString],@"uri",@"image",@"mediaType",size,@"size",[NSNumber numberWithInt:index],@"index", nil];
+                [aListArray addObject:dict];
+                if([aListArray count]==[selectArray count]){
+                    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:aListArray] callbackId:callbackId];
+                }
             }
+        } else {
+            [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:NSLocalizedString(@"photo_download_failed", nil)] callbackId:callbackId];
         }
-        
     }];
 }
 


### PR DESCRIPTION
Implemented the fix to return the appropriate error message for the use case when the user selects one or more images which needs to be downloaded from iCloud and there is no connectivity (to download them).