### PR TITLE
fix: permission alert crash

### DIFF
--- a/src/ios/DMCMediaPicker/DmcPickerViewController.m
+++ b/src/ios/DMCMediaPicker/DmcPickerViewController.m
@@ -168,7 +168,9 @@
                 [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Setting",nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
                 }]];
-                [self presentViewController:alert animated:YES completion:nil];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self presentViewController:alert animated:YES completion:nil];
+                });
             }else {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self getAlassetData];


### PR DESCRIPTION
After the permission was rejected by the user, the app crashes on iOS 13+. This is an attempt to fix this crash. 

The callback seems to enqueue the alert dialog on background thread, which has no permission to access the "UIThread".

Since i'm no obj-c developer, there could other issues arise from this fix. But it helps in our project to prevent the crash.

Also this could fix #104 